### PR TITLE
jQuery 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2018-04-21
+- jQuery 3 compatibility
+
 ## [1.0.0] - 2017-01-01
 ### Added
 - Changelog.

--- a/jquery.viewport.js
+++ b/jquery.viewport.js
@@ -114,7 +114,7 @@
         return true;
     }
 
-    $.extend($.expr[':'], {
+    $.extend($.expr.pseudos, {
         "below-the-fold": function (a, i, m) {
             // m[3] is supposedly the threshold (@theluk)
             return belowTheFold(a, {threshold: int(m[3])});

--- a/jquery.viewport.js
+++ b/jquery.viewport.js
@@ -114,7 +114,7 @@
         return true;
     }
 
-    $.extend($.expr.pseudos, {
+    $.extend($.expr.pseudos || $.expr[':'], {
         "below-the-fold": function (a, i, m) {
             // m[3] is supposedly the threshold (@theluk)
             return belowTheFold(a, {threshold: int(m[3])});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.viewport",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Add viewport selectors to jQuery. For example $(\"img:below-the-fold\").something().",
   "main": "jquery.viewport.js",
   "directories": {


### PR DESCRIPTION
Dear Brian,

this little amendment makes `jquery.viewport` ready for jQuery 3.3.1, following the [standardization of the custom pseudo object](https://github.com/jquery/jquery/issues/2073). Can we humbly ask you to push a 1.0.1 release to npmjs.com?

With kind regards,
Andreas.
